### PR TITLE
Fix Json parsing error

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -14,7 +14,7 @@ module.exports.log = (event, context, callback) => {
     if (err) {
       callback(err);
     } else {
-      const json = JSON.parse(result.toString('ascii'));
+      const json = JSON.parse(result.toString('utf8'));
 
       // Parse a human-readable hostname & program from the log group.
       const logGroup = path.parse(json.logGroup);


### PR DESCRIPTION
First of all thanks for this function!

I was seeing some errors in the logs like this:

```
2020-11-16T16:15:23.491Z	56aac278-cf38-4998-9699-6e3992f60727	ERROR	Uncaught Exception 	
{
    "errorType": "SyntaxError",
    "errorMessage": "Unexpected token \u0000 in JSON at position 13603",
    "stack": [
        "SyntaxError: Unexpected token \u0000 in JSON at position 13603",
        "    at JSON.parse (<anonymous>)",
        "    at Gunzip.cb (/var/task/handler.js:17:25)",
        "    at Gunzip.zlibBufferOnEnd (zlib.js:149:10)",
        "    at Gunzip.emit (events.js:327:22)",
        "    at endReadableNT (_stream_readable.js:1220:12)",
        "    at processTicksAndRejections (internal/process/task_queues.js:84:21)"
    ]
}
```

which seem to be gone after changing the `Buffer.toString` call to use utf8...

WDYT? Should this be configurable maybe?